### PR TITLE
Add Scala to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ you want to add something that needs an installable library, it's your
 call.
 
 
-| Language                 | Native unicode strings | Unicode variable names | Support for unicode digits | Unicode in regexes (TR18) | Unicode normalization |
-|:------------------------:|:----------------------:|:----------------------:|:--------------------------:|:-------------------------:|:---------------------:|
-| [Perl 6](https://perl6.org) | ✓     | ✓      | ✓     | ✓     |  ✓     |
+| Language                 | Native unicode strings | Unicode variable names | Unicode in (other) identifiers | Support for unicode digits | Unicode in regexes (TR18) | Unicode normalization |
+|:------------------------:|:----------------------:|:----------------------:|:------------------------------:|:--------------------------:|:-------------------------:|:---------------------:|
+| [Perl 6](https://perl6.org)      | ✓     | ✓                             | ?                        | ✓     | ✓     |  ✓     |
+| [Scala](https://scala-lang.org/) | ✓     | ✓ <sup id="a1">[1](#f1)</sup> | ✓ <sup>[1](#f1)</sup>    | ?     | ✓     |  ✓     |
+
+
+
+<b id="f1">1</b> By using a backtick `` ` `` as an escape around the variable name. e.g. ``val `😽` = "🐈" ``. [↩](#a1)


### PR DESCRIPTION
Scala allows all identifiers to be Unicode. Since the original headers only list variables, an extra column is added for "other" identifiers. We could split those further in, for instance, `variable`, `method`, `class`, `package` and `interface` names.

An other option is to not have a "plain" ✓ in the column, but some indication of which type of indicators can be Unicode in the described language.